### PR TITLE
Changes version range of node-sass in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "antd": "^3.2.0",
     "less-loader": "^4.0.5",
-    "sass-loader": "^6.0.6"
+    "sass-loader": ">=6.0.6 <8"
   },
   "devDependencies": {
     "antd": "^3.2.0",


### PR DESCRIPTION
Changes version range of node-sass in peer dependencies to include node-sass 7 which is working fine.